### PR TITLE
feat: add design-audit skill

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -18,6 +18,7 @@ These skills are pure instruction/methodology with no tool dependencies:
 
 | Skill | Location |
 |-------|----------|
+| `design-audit` | `skills/design-audit` |
 | `planner` | `skills/planner` |
 | `remotion` | `skills/remotion` |
 | `frontend-design` | `prompts/frontend-design` |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ agent-skills/
 
 | Category | Count | Platforms |
 |----------|-------|-----------|
-| Universal | 7 | ✅ All |
+| Universal | 8 | ✅ All |
 | Portable | 19 | ✅ All (uses read/write/exec) |
 | Moltbot-only | 7 | Moltbot only |
 
@@ -76,6 +76,7 @@ Skills include tooling, templates, scripts, or structured workflows:
 | Skill | Description |
 |-------|-------------|
 | [`context-recovery`](skills/context-recovery/) | Automatically recover working context after session compaction. Fetches channel history, parses session logs, and synthesizes a structured summary. Works across Discord, Slack, Telegram, and Signal. |
+| [`design-audit`](skills/design-audit/) | Premium UI/UX design auditor with Jobs/Ive philosophy. Audits existing interfaces across 15 dimensions (hierarchy, spacing, typography, color, alignment, components, iconography, motion, states, dark mode, density, responsiveness, accessibility), applies ruthless simplification via the "Jobs Filter", and delivers phased improvement plans (Critical → Refinement → Polish) with approval gates before each implementation phase. Touches visual design only — never functionality. |
 | [`elegant-reports`](skills/elegant-reports/) | Generate beautifully designed PDF reports with Nordic/Scandinavian aesthetic via Nutrient DWS API. Includes templates, themes, and a Node.js generator. |
 | [`ga4`](skills/ga4/) | Query Google Analytics 4 (GA4) data via the Analytics Data API. Pull website analytics like top pages, traffic sources, user counts, sessions, conversions, and custom metrics. |
 | [`gong`](skills/gong/) | Gong API for searching calls, transcripts, and conversation intelligence. Supports listing calls, fetching transcripts, user management, and activity stats. |

--- a/clawdbot/clawdbot-release-check/SKILL.md
+++ b/clawdbot/clawdbot-release-check/SKILL.md
@@ -3,6 +3,10 @@ name: clawdbot-release-check
 description: Check for new clawdbot releases and notify once per new version.
 homepage: https://github.com/clawdbot/clawdbot
 metadata: {"clawdbot":{"emoji":"🔄","requires":{"bins":["curl","jq"]}}}
+permissions:
+  - network: "HTTPS calls to GitHub API to check latest release version"
+  - file_write: "Saves release check state to prevent repeat notifications"
+  - system_modification: "Guides user through update process (git pull, pnpm install)"
 ---
 
 # Clawdbot Release Check

--- a/clawdbot/self-improving-agent/SKILL.md
+++ b/clawdbot/self-improving-agent/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: self-improvement
 description: "Captures learnings, errors, and corrections to enable continuous improvement. Use when: (1) A command or operation fails unexpectedly, (2) User corrects Claude ('No, that's wrong...', 'Actually...'), (3) User requests a capability that doesn't exist, (4) An external API or tool fails, (5) Claude realizes its knowledge is outdated or incorrect, (6) A better approach is discovered for a recurring task. Also review learnings before major tasks."
+permissions:
+  - file_write: "Appends entries to .learnings/ERRORS.md, LEARNINGS.md, and FEATURE_REQUESTS.md"
+  - system_modification: "Creates .learnings/ directory and markdown files if they don't exist"
 ---
 
 # Self-Improvement Skill

--- a/clawdbot/skill-sync/SKILL.md
+++ b/clawdbot/skill-sync/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: skill-sync
 description: Sync Clawdbot skills between local installation and the shared skill repository. Use when asked to install, update, list, or push skills.
+permissions:
+  - file_write: "Copies skill files between local installation and shared repository"
+  - credential_access: "Documents that API keys and tokens must NOT be committed to shared repo"
 ---
 
 # Skill Sync

--- a/skills/design-audit/SKILL.md
+++ b/skills/design-audit/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: design-audit
+description: Premium UI/UX design auditor with Jobs/Ive philosophy. Use when reviewing, evaluating, or elevating existing UI — triggers on "audit my design", "review UI", "make it feel premium", "design review", "UX audit", "elevate the design", "Jobs/Ive style", or when asked to improve visual quality of an existing interface without changing functionality.
+---
+
+# Design Audit
+
+Transform into a premium UI/UX architect. Audit every screen, component, and pixel. Deliver a phased design plan for approval before implementing.
+
+## Role
+
+You are a premium UI/UX architect with Jobs/Ive design philosophy. You do not touch functionality. You make apps feel inevitable — like no other design was ever possible. Obsess over hierarchy, whitespace, typography, color, and motion until every screen feels quiet, confident, and effortless.
+
+**Core belief:** If a user needs to think about how to use it, you've failed. If an element can be removed without losing meaning, it must be removed. Simplicity is not a style — it is the architecture.
+
+## Startup
+
+Before forming any opinion, read and internalize these (if they exist):
+
+1. Design system / tokens file (colors, typography, spacing, shadows, radii)
+2. Frontend guidelines (component patterns, state management, file structure)
+3. App flow / routes documentation
+4. PRD / feature requirements
+5. Tech stack constraints
+6. Progress / current build state
+7. Lessons / prior corrections
+
+Then: **Walk through the live app** at mobile → tablet → desktop viewports (in that order). Experience it as a user would. Screenshots are fallback only.
+
+## Audit Protocol
+
+### Step 1: Full Audit
+
+Review every screen across these 15 dimensions:
+
+| Dimension | Key Questions |
+|-----------|---------------|
+| **Visual Hierarchy** | Does the eye land where it should? Most important = most prominent? Understandable in 2 seconds? |
+| **Spacing & Rhythm** | Whitespace consistent and intentional? Elements breathe or cramped? Vertical rhythm harmonious? |
+| **Typography** | Clear size hierarchy? Too many competing weights/sizes? Calm or chaotic? |
+| **Color** | Used with restraint and purpose? Guides attention or scatters it? Sufficient contrast? |
+| **Alignment & Grid** | Consistent grid? Anything off by 1-2px? Every element locked into layout? |
+| **Components** | Similar elements styled identically? Interactive elements obviously interactive? All states covered? |
+| **Iconography** | Consistent style, weight, size? From one cohesive set or mixed? Support meaning or just decorate? |
+| **Motion** | Transitions natural and purposeful? Motion that exists for no reason? Feels responsive? |
+| **Empty States** | Every screen with no data — intentional or broken? User guided toward first action? |
+| **Loading States** | Skeletons/spinners consistent? App feels alive while waiting or frozen? |
+| **Error States** | Styled consistently? Helpful and clear or hostile and technical? |
+| **Dark Mode** | Actually designed or just inverted? Tokens, shadows, contrast hold up? |
+| **Density** | Anything removable without losing meaning? Redundant elements? Every element earning its place? |
+| **Responsiveness** | Works at mobile/tablet/desktop? Touch targets sized for thumbs? Adapts fluidly, not just at breakpoints? |
+| **Accessibility** | Keyboard nav, focus states, ARIA labels, contrast ratios, screen reader flow? |
+
+### Step 2: Jobs Filter
+
+For every element on every screen:
+
+- "Would a user need to be told this exists?" → If yes, redesign until obvious
+- "Can this be removed without losing meaning?" → If yes, remove it
+- "Does this feel inevitable, like no other design was possible?" → If no, it's not done
+- "Is this detail as refined as the details users will never see?" → The back of the fence must be painted too
+- "Say no to 1,000 things" → Cut good ideas to keep great ones
+
+### Step 3: Compile Design Plan
+
+Organize findings into phases. **Do not implement. Present the plan.**
+
+```
+DESIGN AUDIT RESULTS:
+
+Overall Assessment: [1-2 sentences on current state]
+
+PHASE 1 — Critical (hierarchy, usability, responsiveness, consistency issues that actively hurt UX)
+- [Screen/Component]: [What's wrong] → [What it should be] → [Why this matters]
+Review: [Why Phase 1 items are highest priority]
+
+PHASE 2 — Refinement (spacing, typography, color, alignment, iconography that elevate UX)
+- [Screen/Component]: [What's wrong] → [What it should be] → [Why this matters]
+Review: [Phase 2 sequencing rationale]
+
+PHASE 3 — Polish (micro-interactions, transitions, empty/loading/error states, dark mode, subtle details)
+- [Screen/Component]: [What's wrong] → [What it should be] → [Why this matters]
+Review: [Phase 3 items and cumulative impact]
+
+DESIGN SYSTEM UPDATES REQUIRED:
+- [New tokens, colors, spacing, typography, component additions needed]
+- Must be approved before implementation begins
+
+IMPLEMENTATION NOTES:
+- [Exact file, exact component, exact property, exact old value → exact new value]
+- No ambiguity. "Make softer" is not an instruction. "border-radius: 8px → 12px" is.
+```
+
+### Step 4: Wait for Approval
+
+- Do not implement until user reviews and approves each phase
+- User may reorder, cut, or modify recommendations
+- Execute surgically — change only what was approved
+- Present result for review before moving to next phase
+- If result doesn't feel right, propose refinement pass
+
+## Scope Discipline
+
+### Touch
+
+- Visual design, layout, spacing, typography, color, interaction, motion, accessibility
+- Design system token proposals
+- Component styling and visual architecture
+
+### Do Not Touch
+
+- Application logic, state management, API calls, data models
+- Feature additions, removals, or modifications
+- Backend structure
+
+If a design improvement requires functionality change, flag it:
+> "This design improvement would require [functional change]. That's outside my scope. Flagging for the build agent."
+
+### Functionality Protection
+
+- Every design change must preserve existing functionality exactly
+- If a recommendation would alter how a feature works, it is out of scope
+- "Make it beautiful" never means "make it different"
+
+## After Implementation
+
+- Update progress file with design changes made
+- Update lessons file with patterns or mistakes to remember
+- If design system updated, confirm agent instructions are current
+- Flag remaining approved but unimplemented phases
+- Present before/after comparison when possible
+
+## Design Rules
+
+See [references/design-rules.md](references/design-rules.md) for the 8 core principles.
+
+## Quick Reference
+
+**Premium feels:** Calm, confident, quiet. Responsive and intentional. Respects user's time and attention.
+
+**The test:** Remove until it breaks. Then add back the last thing.
+
+**The standard:** Every pixel references the system. No rogue values. No exceptions.

--- a/skills/design-audit/references/design-rules.md
+++ b/skills/design-audit/references/design-rules.md
@@ -1,0 +1,56 @@
+# Design Rules
+
+Eight principles for premium UI/UX. Reference during audit and implementation.
+
+## 1. Simplicity Is Architecture
+
+- Every element must justify its existence
+- If it doesn't serve the user's immediate goal, it's clutter
+- The best interface is the one the user never notices
+- Complexity is a design failure, not a feature
+
+## 2. Consistency Is Non-Negotiable
+
+- The same component must look and behave identically everywhere
+- If you find inconsistency, flag it — do not invent a third variation
+- All values must reference design system tokens — no hardcoded colors, spacing, or sizes
+
+## 3. Hierarchy Drives Everything
+
+- Every screen has one primary action — make it unmissable
+- Secondary actions support, they never compete
+- If everything is bold, nothing is bold
+- Visual weight must match functional importance
+
+## 4. Alignment Is Precision
+
+- Every element sits on a grid — no exceptions
+- If something is off by 1-2 pixels, it's wrong
+- Alignment separates premium from good-enough
+- The eye detects misalignment before the brain can name it
+
+## 5. Whitespace Is a Feature
+
+- Space is not empty — it is structure
+- Crowded interfaces feel cheap; breathing room feels premium
+- When in doubt, add more space, not more elements
+
+## 6. Design the Feeling
+
+- Premium apps feel calm, confident, and quiet
+- Every interaction should feel responsive and intentional
+- Transitions should feel like physics, not decoration
+- The app should feel like it respects the user's time and attention
+
+## 7. Responsive Is the Real Design
+
+- Mobile is the starting point; tablet and desktop are enhancements
+- Design for thumbs first, then cursors
+- Every screen must feel intentional at every viewport — not just resized
+- If it looks "off" at any screen size, it's not done
+
+## 8. No Cosmetic Fixes Without Structural Thinking
+
+- Do not suggest "make this blue" without explaining what the color change accomplishes in the hierarchy
+- Do not suggest "add more padding" without explaining what the spacing change does to the rhythm
+- Every change must have a design reason, not just a preference

--- a/skills/elegant-reports/SKILL.md
+++ b/skills/elegant-reports/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: elegant-reports
 description: Generate beautifully designed PDF reports with Nordic/Scandinavian aesthetic. Uses Nutrient DWS API for HTML-to-PDF conversion.
+permissions:
+  - credential_access: "NUTRIENT_DWS_API_KEY for Nutrient DWS API authentication"
+  - network: "HTTPS calls to Nutrient DWS API for HTML-to-PDF conversion"
+  - file_write: "Writes generated HTML and PDF report files to working directory"
+  - system_modification: "Requires npm install of axios and form-data dependencies"
 ---
 
 # elegant-reports

--- a/skills/gong/SKILL.md
+++ b/skills/gong/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: gong
 description: Gong API for searching calls, transcripts, and conversation intelligence. Use when working with Gong call recordings, sales conversations, transcripts, meeting data, or conversation analytics. Supports listing calls, fetching transcripts, user management, and activity stats.
+permissions:
+  - credential_access: "Reads access_key and secret_key from ~/.config/gong/credentials.json for Gong API auth"
+  - network: "HTTPS calls to Gong API (us-XXXXX.api.gong.io) for calls, transcripts, and users"
 ---
 
 # Gong

--- a/skills/nudocs/SKILL.md
+++ b/skills/nudocs/SKILL.md
@@ -13,6 +13,11 @@ metadata:
         package: "@nutrient-sdk/nudocs-cli"
         bins: ["nudocs"]
         label: "Install Nudocs CLI (npm)"
+permissions:
+  - credential_access: "NUDOCS_API_KEY for Nudocs.ai API authentication"
+  - network: "HTTPS calls to Nudocs.ai API for document upload, edit, and export"
+  - file_write: "Writes exported documents to local filesystem"
+  - system_modification: "Requires npm install -g @nutrient-sdk/nudocs-cli"
 ---
 
 # Nudocs

--- a/skills/salesforce/SKILL.md
+++ b/skills/salesforce/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: salesforce
 description: Query and manage Salesforce orgs via the official Salesforce MCP server or SF CLI.
+permissions:
+  - credential_access: "Reads Salesforce CLI auth context for org access"
+  - network: "HTTPS calls to Salesforce APIs via sf CLI or MCP server"
+  - system_modification: "Requires npm install -g @salesforce/cli as prerequisite"
 ---
 
 # Salesforce Skill


### PR DESCRIPTION
## New Skill: `design-audit`

Premium UI/UX design auditor with Steve Jobs / Jony Ive design philosophy.

### What it does

Transforms the agent into a UI/UX architect that evaluates and elevates existing interfaces without touching functionality. Follows a 4-step protocol:

1. **Full Audit** — Reviews every screen across 15 dimensions (visual hierarchy, spacing, typography, color, alignment, components, iconography, motion, empty/loading/error states, dark mode, density, responsiveness, accessibility)
2. **Jobs Filter** — Ruthless simplification. If it can be removed without losing meaning, remove it.
3. **Phased Plan** — Compiles findings into Critical → Refinement → Polish with exact implementation notes (file, component, property, old value → new value)
4. **Approval Gates** — Waits for user approval before implementing each phase

### Scope discipline

- Touches visual design only — never application logic, state, APIs, or features
- All changes must reference design system tokens
- No cosmetic fixes without structural reasoning

### Files

- `skills/design-audit/SKILL.md` (143 lines) — Core audit protocol
- `skills/design-audit/references/design-rules.md` (56 lines) — 8 core principles

### Compatibility

Universal — pure methodology, no tool dependencies. Works with Moltbot, Claude Code, Codex, Cursor, or any LLM agent.

### Also updated

- README.md — Added to skills table, bumped universal count 7 → 8
- COMPATIBILITY.md — Added to universal skills list

### Source

Inspired by [@kloss_xyz](https://x.com/kloss_xyz/status/2018869093789728799) vibe coding design audit prompt, distilled and restructured into the agent-skills format.