### PR TITLE
Fix skill name mismatches and dead planner references

### DIFF
--- a/clawdbot/self-improving-agent/SKILL.md
+++ b/clawdbot/self-improving-agent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: self-improvement
+name: self-improving-agent
 description: "Captures learnings, errors, and corrections to enable continuous improvement. Use when: (1) A command or operation fails unexpectedly, (2) User corrects Claude ('No, that's wrong...', 'Actually...'), (3) User requests a capability that doesn't exist, (4) An external API or tool fails, (5) Claude realizes its knowledge is outdated or incorrect, (6) A better approach is discovered for a recurring task. Also review learnings before major tasks."
 permissions:
   - file_write: "Appends learning, error, and feature-request notes inside the local .learnings directory."

--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -17,7 +17,7 @@ Create structured, orchestrator-ready plans for multi-task projects.
 
 ## Quick Start
 
-Load the full planner prompt from `prompts/planner.md` and follow its process:
+Follow this process:
 
 1. **Phase 0**: Clarify requirements (ask up to 5 targeted questions)
 2. **Phase 1**: Research & understand the codebase
@@ -127,9 +127,8 @@ Or invoke directly:
 
 ---
 
-## Files
+## Related
 
-- `prompts/planner.md` — Full planner agent prompt
-- `prompts/parallel-task.md` — Parallel task worker prompt
+- [`parallel-task`](../parallel-task/) — Parallel task worker that executes the plan this skill produces
 
-Both are based on am-will's codex-skills prompts.
+Adapted from am-will's codex-skills planner/parallel-task prompts.

--- a/skills/remotion/SKILL.md
+++ b/skills/remotion/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: remotion-best-practices
-description: Best practices for Remotion - Video creation in React
+name: remotion
+description: Best practices for Remotion video creation in React — compositions, sequences, animation, timing, and rendering. Use when building, reviewing, or debugging Remotion videos.
 metadata:
   tags: remotion, video, react, animation, composition
 ---


### PR DESCRIPTION
Small correctness pass for skill discovery + honest docs:

- **self-improving-agent**: `name:` was `self-improvement` → now matches the dir/skill id
- **remotion**: `name:` was `remotion-best-practices` → now `remotion` (matches dir + _meta.json slug); also gave the description real trigger keywords (was a bare one-liner)
- **planner**: removed dead references to `prompts/planner.md` and `prompts/parallel-task.md` (those files never existed in the repo). The SKILL.md already contains the full process/template inline; it now links to the real `parallel-task` skill instead.

SKILL.md-only — no README/COMPATIBILITY changes, so it won't conflict with #22.